### PR TITLE
Create simplified and updated synchronization algorithm

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -111,6 +111,9 @@ functions:
               - dataTable
               - Arn
           - Fn::GetAtt:
+              - stateTable
+              - Arn
+          - Fn::GetAtt:
               - distributeTable
               - Arn
       - Effect: Allow

--- a/config/user_config.json
+++ b/config/user_config.json
@@ -8,6 +8,6 @@
   "system-storage": "key-value",
   "heartbeat-frequency": 12,
   "worker-queue": "dynamodb",
-  "distributor-queue": "dynamodb",
+  "distributor-queue": "sqs",
   "client-channel": "sqs"
 }

--- a/functions/aws/config.py
+++ b/functions/aws/config.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import functions.aws.control as control
 import functions.aws.model as model
+from functions.aws.control import distributor_queue
 
 
 class Storage(Enum):
@@ -65,18 +66,18 @@ class Config:
             raise RuntimeError("Not implemented!")
 
         # configure distributor queue
-        self._distributor_queue: Optional[control.DistributorQueue]
+        self._distributor_queue: Optional[distributor_queue.DistributorQueue]
         if with_distributor_queue:
             self._distributor_queue_type = {
                 "dynamodb": QueueType.DYNAMODB,
                 "sqs": QueueType.SQS,
             }.get(environ["DISTRIBUTOR_QUEUE"])
             if self._distributor_queue_type == QueueType.DYNAMODB:
-                self._distributor_queue = control.DistributorQueueDynamo(
+                self._distributor_queue = distributor_queue.DistributorQueueDynamo(
                     f"{self._deployment_name}"
                 )
             elif self._distributor_queue_type == QueueType.SQS:
-                self._distributor_queue = control.DistributorQueueSQS(
+                self._distributor_queue = distributor_queue.DistributorQueueSQS(
                     environ["QUEUE_PREFIX"], self.deployment_region
                 )
             else:
@@ -125,7 +126,7 @@ class Config:
         return self._system_storage
 
     @property
-    def distributor_queue(self) -> Optional[control.DistributorQueue]:
+    def distributor_queue(self) -> Optional[distributor_queue.DistributorQueue]:
         return self._distributor_queue
 
     @property

--- a/functions/aws/config.py
+++ b/functions/aws/config.py
@@ -6,6 +6,7 @@ from typing import Optional
 import functions.aws.control as control
 import functions.aws.model as model
 from functions.aws.control import distributor_queue
+from functions.aws.control.distributor_queue import DistributorQueue
 
 
 class Storage(Enum):
@@ -126,7 +127,7 @@ class Config:
         return self._system_storage
 
     @property
-    def distributor_queue(self) -> Optional[distributor_queue.DistributorQueue]:
+    def distributor_queue(self) -> Optional[DistributorQueue]:
         return self._distributor_queue
 
     @property

--- a/functions/aws/control/__init__.py
+++ b/functions/aws/control/__init__.py
@@ -1,9 +1,10 @@
 from .channel import ClientChannel, ClientChannelSQS, ClientChannelTCP  # noqa
-from .distributor_queue import (  # noqa
-    DistributorQueue,
-    DistributorQueueDynamo,
-    DistributorQueueSQS,
-)
+
+# from .distributor_queue import (  # noqa
+#    DistributorQueue,
+#    DistributorQueueDynamo,
+#    DistributorQueueSQS,
+# )
 from .dynamo import DynamoStorage  # noqa
 from .s3 import S3Storage  # noqa
 from .storage import Storage  # noqa

--- a/functions/aws/control/distributor_events.py
+++ b/functions/aws/control/distributor_events.py
@@ -168,7 +168,10 @@ class DistributorCreateNode(DistributorEvent):
             }
 
         # The node is no longer locked, but the update is not there
-        if system_node.pending_updates[0] != self.event_id:
+        if (
+            len(system_node.pending_updates) > 0
+            and system_node.pending_updates[0] != self.event_id
+        ):
 
             if (
                 system_node.Status == SystemNode.Status.LOCKED
@@ -313,7 +316,10 @@ class DistributorSetData(DistributorEvent):
             }
 
         # The node is no longer locked, but the update is not there
-        if system_node.pending_updates[0] != self.event_id:
+        if (
+            len(system_node.pending_updates) > 0
+            and system_node.pending_updates[0] != self.event_id
+        ):
 
             if (
                 system_node.Status == SystemNode.Status.LOCKED
@@ -454,7 +460,10 @@ class DistributorDeleteNode(DistributorEvent):
             }
 
         # The node is no longer locked, but the update is not there
-        if system_node.pending_updates[0] != self.event_id:
+        if (
+            len(system_node.pending_updates) > 0
+            and system_node.pending_updates[0] != self.event_id
+        ):
 
             if (
                 system_node.Status == SystemNode.Status.LOCKED

--- a/functions/aws/control/distributor_events.py
+++ b/functions/aws/control/distributor_events.py
@@ -167,14 +167,15 @@ class DistributorCreateNode(DistributorEvent):
                 "reason": f"node {self.node.path} does not exist in system storage",
             }
 
+        print(system_node.pending_updates)
         # The node is no longer locked, but the update is not there
         if (
-            len(system_node.pending_updates) > 0
-            and system_node.pending_updates[0] != self.event_id
+            len(system_node.pending_updates) == 0
+            or system_node.pending_updates[0] != self.event_id
         ):
 
             if (
-                system_node.Status == SystemNode.Status.LOCKED
+                system_node.status == SystemNode.Status.LOCKED
                 and system_node.lock.timestamp == self.lock_timestamp
             ):
                 # Now we try to commit the node, but only if we still own a lock.
@@ -201,6 +202,7 @@ class DistributorCreateNode(DistributorEvent):
                         ),
                     ],
                 )
+                print("Status", status)
                 if status:
                     print("Committed the node!")
                 else:

--- a/functions/aws/control/distributor_queue.py
+++ b/functions/aws/control/distributor_queue.py
@@ -19,6 +19,10 @@ class DistributorQueue(ABC):
     ) -> None:
         pass
 
+    @abstractmethod
+    def push_and_count(self, event: DistributorEvent, client: Client) -> SystemCounter:
+        pass
+
 
 class DistributorQueueDynamo(DistributorQueue):
     def __init__(self, deployment_name: str):
@@ -55,6 +59,11 @@ class DistributorQueueDynamo(DistributorQueue):
             },
         )
 
+    def push_and_count(self, event: DistributorEvent, client: Client) -> SystemCounter:
+        raise NotImplementedError(
+            "Counting events is not supported in the DistributorQueueDynamo!"
+        )
+
 
 class DistributorQueueSQS(DistributorQueue):
     def __init__(self, name: str, region: str):
@@ -86,3 +95,26 @@ class DistributorQueueSQS(DistributorQueue):
             MessageGroupId="0",
             MessageDeduplicationId=str(counter.sum),
         )
+
+    def push_and_count(self, event: DistributorEvent, client: Client) -> SystemCounter:
+
+        client_serialization = {
+            x: self._type_serializer.serialize(y) for x, y in client.serialize().items()
+        }
+        payload: Dict[str, str] = {
+            **client_serialization,  # type: ignore
+            **event.serialize(self._type_serializer),
+        }
+
+        attributes: dict = {}
+        response = self._sqs_client.send_message(
+            QueueUrl=self._sqs_queue_url,
+            MessageBody=json.dumps(payload),
+            MessageAttributes=attributes,
+            MessageGroupId="0",
+            MessageDeduplicationId=event.event_id,
+        )
+        print(response)
+        # We use SQS sequence number as the counter
+        new_ctr = int(response["SequenceNumber"])
+        return SystemCounter.from_raw_data([new_ctr])

--- a/functions/aws/control/distributor_queue.py
+++ b/functions/aws/control/distributor_queue.py
@@ -114,7 +114,6 @@ class DistributorQueueSQS(DistributorQueue):
             MessageGroupId="0",
             MessageDeduplicationId=event.event_id,
         )
-        print(response)
         # We use SQS sequence number as the counter
         new_ctr = int(response["SequenceNumber"])
         return SystemCounter.from_raw_data([new_ctr])

--- a/functions/aws/distributor.py
+++ b/functions/aws/distributor.py
@@ -113,7 +113,7 @@ def handler(event: dict, context):
                         "B": record["messageAttributes"]["data"]["binaryValue"]
                     }
                 counter = SystemCounter.from_raw_data(
-                    record["attributes"]["SequenceNumber"]
+                    [int(record["attributes"]["SequenceNumber"])]
                 )
             else:
                 raise NotImplementedError()

--- a/functions/aws/init.py
+++ b/functions/aws/init.py
@@ -45,10 +45,7 @@ def init(service_name: str, region: str):
         Item={
             "path": {"S": "/"},
             "cFxidSys": {"L": [{"N": "0"}]},
-            # "cFxidEpoch": {"SS": ["0"]},
             "mFxidSys": {"L": [{"N": "0"}]},
-            "pFxidSys": {"L": [{"N": "0"}]},
-            # "mFxidEpoch": {"NS": ["0"]},
             "children": {"L": []},
         },
     )
@@ -57,7 +54,6 @@ def init(service_name: str, region: str):
         Item={
             "path": {"S": "/"},
             "cFxidSys": {"L": [{"N": "0"}]},
-            # "cFxidEpoch": {"NS": ["0"]},
             "mFxidSys": {"L": [{"N": "0"}]},
             "mFxidEpoch": {"SS": [""]},
             "children": {"L": []},

--- a/functions/aws/model/system_storage.py
+++ b/functions/aws/model/system_storage.py
@@ -36,7 +36,7 @@ class Node:
 
     @property
     def pending_updates(self) -> List[str]:
-        assert self._pending_updates
+        assert self._pending_updates is not None
         return self._pending_updates
 
     @pending_updates.setter

--- a/functions/aws/model/system_storage.py
+++ b/functions/aws/model/system_storage.py
@@ -321,6 +321,7 @@ class DynamoStorage(Storage):
             ret = self._state_storage._dynamodb.transact_write_items(
                 TransactItems=transaction_items, ReturnConsumedCapacity="TOTAL"  # type: ignore
             )
+            print("Commit", ret)
 
             for table in ret["ConsumedCapacity"]:
                 StorageStatistics.instance().add_write_units(

--- a/functions/aws/model/system_storage.py
+++ b/functions/aws/model/system_storage.py
@@ -260,23 +260,6 @@ class DynamoStorage(Storage):
         # strip traling comma - boto3 will not accept that
         update_expr = update_expr[:-1]
 
-        print(
-            {
-                "TableName": self._state_storage.storage_name,
-                # path to the node
-                "Key": {"path": {"S": node.path}},
-                # create timelock
-                "UpdateExpression": update_expr,
-                # lock doesn't exist or it's already expired
-                "ConditionExpression": "(attribute_exists(timelock)) "
-                "and (timelock = :mytimelock)",
-                # timelock value
-                "ExpressionAttributeValues": {
-                    ":mytimelock": {"N": str(timestamp)},
-                    **update_values,
-                },
-            }
-        )
         return {
             "TableName": self._state_storage.storage_name,
             # path to the node
@@ -475,5 +458,7 @@ class DynamoStorage(Storage):
             dynamo_node.pending_updates = self._type_deserializer.deserialize(
                 data["pendingUpdates"]
             )
+        else:
+            dynamo_node.pending_updates = []
 
         return dynamo_node

--- a/functions/aws/model/system_storage.py
+++ b/functions/aws/model/system_storage.py
@@ -353,7 +353,6 @@ class DynamoStorage(Storage):
                     )
         except self._state_storage.errorSupplier.TransactionCanceledException as e:
             success = False
-            print(e.response)
             if return_old_on_failure is not None:
                 for idx, old_value in enumerate(e.response["CancellationReasons"]):
                     old_values.append(

--- a/functions/aws/model/system_storage.py
+++ b/functions/aws/model/system_storage.py
@@ -435,6 +435,7 @@ class DynamoStorage(Storage):
             # path to the node
             Key={"path": {"S": node.path}},
             ReturnConsumedCapacity="TOTAL",
+            ConsistentRead=True,
         )
         StorageStatistics.instance().add_read_units(
             ret["ConsumedCapacity"]["CapacityUnits"]

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -138,6 +138,7 @@ class CreateNodeExecutor(Executor):
                             NodeDataType.CHILDREN,
                         ]
                     ),
+                    self.event_id,
                 ),
                 system_storage.generate_commit_node(
                     self._parent_node,
@@ -256,7 +257,10 @@ class SetDataExecutor(Executor):
         # the new data will be written by the distributor
         self._system_node.modified = Version(self._counter, None)
         if not system_storage.commit_node(
-            self._system_node, self._timestamp, set([NodeDataType.MODIFIED])
+            self._system_node,
+            self._timestamp,
+            set([NodeDataType.MODIFIED]),
+            self.event_id,
         ):
             return (False, {"status": "failure", "reason": "unknown"})
         end_commit = time.time()
@@ -351,7 +355,11 @@ class DeleteNodeExecutor(Executor):
                     set([NodeDataType.CHILDREN]),
                 )
             ],
-            [system_storage.generate_delete_node(self._node, self._timestamp)],
+            [
+                system_storage.generate_delete_node(
+                    self._node, self._timestamp, self.event_id
+                )
+            ],
         )
 
         return (True, {})

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -112,6 +112,8 @@ class CreateNodeExecutor(Executor):
         # FIXME: keep the information if base64 encoding is actually applied?
         # Important for Redis
         self._node.data_b64 = self.op.data_b64
+        # parent now has one child more
+        self._parent_node.children.append(pathlib.Path(self.op.path).name)
 
         return (True, {})
 
@@ -126,8 +128,6 @@ class CreateNodeExecutor(Executor):
 
         # FIXME: make both operations concurrently
         # unlock parent
-        # parent now has one child more
-        self._parent_node.children.append(pathlib.Path(self.op.path).name)
         system_storage.commit_node(
             self._parent_node, self._parent_timestamp, set([NodeDataType.CHILDREN])
         )

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -126,27 +126,27 @@ class CreateNodeExecutor(Executor):
         self._node.created = Version(self._counter, None)
         self._node.modified = Version(self._counter, None)
 
-        system_storage.commit_nodes(
-            [
-                system_storage.generate_commit_node(
-                    self._node,
-                    self._timestamp,
-                    set(
-                        [
-                            NodeDataType.CREATED,
-                            NodeDataType.MODIFIED,
-                            NodeDataType.CHILDREN,
-                        ]
-                    ),
-                    self.event_id,
-                ),
-                system_storage.generate_commit_node(
-                    self._parent_node,
-                    self._parent_timestamp,
-                    set([NodeDataType.CHILDREN]),
-                ),
-            ],
-        )
+        # system_storage.commit_nodes(
+        #    [
+        #        system_storage.generate_commit_node(
+        #            self._node,
+        #            self._timestamp,
+        #            set(
+        #                [
+        #                    NodeDataType.CREATED,
+        #                    NodeDataType.MODIFIED,
+        #                    NodeDataType.CHILDREN,
+        #                ]
+        #            ),
+        #            self.event_id,
+        #        ),
+        #        system_storage.generate_commit_node(
+        #            self._parent_node,
+        #            self._parent_timestamp,
+        #            set([NodeDataType.CHILDREN]),
+        #        ),
+        #    ],
+        # )
 
         return (True, {})
 

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -309,6 +309,9 @@ class DeleteNodeExecutor(Executor):
                 break
         assert self._parent_node
 
+        # remove child from parent node
+        self._parent_node.children.remove(pathlib.Path(self.op.path).name)
+
         return (True, {})
 
     def distributor_push(self, client: Client, distributor_queue: DistributorQueue):
@@ -330,9 +333,6 @@ class DeleteNodeExecutor(Executor):
         assert self._timestamp
         assert self._parent_node
         assert self._parent_timestamp
-
-        # remove child from parent node
-        self._parent_node.children.remove(pathlib.Path(self.op.path).name)
 
         # commit system storage
         # FIXME: as a transaction

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -126,27 +126,28 @@ class CreateNodeExecutor(Executor):
         self._node.created = Version(self._counter, None)
         self._node.modified = Version(self._counter, None)
 
-        # system_storage.commit_nodes(
-        #    [
-        #        system_storage.generate_commit_node(
-        #            self._node,
-        #            self._timestamp,
-        #            set(
-        #                [
-        #                    NodeDataType.CREATED,
-        #                    NodeDataType.MODIFIED,
-        #                    NodeDataType.CHILDREN,
-        #                ]
-        #            ),
-        #            self.event_id,
-        #        ),
-        #        system_storage.generate_commit_node(
-        #            self._parent_node,
-        #            self._parent_timestamp,
-        #            set([NodeDataType.CHILDREN]),
-        #        ),
-        #    ],
-        # )
+        # If we fail, we do not notify the user - it is now the job of the distributor.
+        system_storage.commit_nodes(
+            [
+                system_storage.generate_commit_node(
+                    self._node,
+                    self._timestamp,
+                    set(
+                        [
+                            NodeDataType.CREATED,
+                            NodeDataType.MODIFIED,
+                            NodeDataType.CHILDREN,
+                        ]
+                    ),
+                    self.event_id,
+                ),
+                system_storage.generate_commit_node(
+                    self._parent_node,
+                    self._parent_timestamp,
+                    set([NodeDataType.CHILDREN]),
+                ),
+            ],
+        )
 
         return (True, {})
 
@@ -367,13 +368,11 @@ class DeleteNodeExecutor(Executor):
                     self._parent_node,
                     self._parent_timestamp,
                     set([NodeDataType.CHILDREN]),
-                )
-            ],
-            [
+                ),
                 system_storage.generate_delete_node(
                     self._node, self._timestamp, self.event_id
-                )
-            ],
+                ),
+            ]
         )
 
         return (True, {})

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -14,7 +14,7 @@ from faaskeeper.operations import (
     RequestOperation,
     SetData,
 )
-from faaskeeper.version import Version
+from faaskeeper.version import SystemCounter, Version
 from functions.aws.control.channel import Client
 from functions.aws.control.distributor_events import (
     DistributorCreateNode,
@@ -27,8 +27,13 @@ from functions.aws.stats import TimingStatistics
 
 
 class Executor(ABC):
-    def __init__(self, op: RequestOperation):
+    def __init__(self, event_id: str, op: RequestOperation):
         self._op = op
+        self._event_id = event_id
+
+    @property
+    def event_id(self) -> str:
+        return self._event_id
 
     @abstractmethod
     def lock_and_read(self, system_storage: SystemStorage) -> Tuple[bool, dict]:
@@ -44,8 +49,9 @@ class Executor(ABC):
 
 
 class CreateNodeExecutor(Executor):
-    def __init__(self, op: CreateNode):
-        super().__init__(op)
+    def __init__(self, event_id: str, op: CreateNode):
+        super().__init__(event_id, op)
+        self._counter: Optional[SystemCounter] = None
 
     @property
     def op(self) -> CreateNode:
@@ -98,28 +104,25 @@ class CreateNodeExecutor(Executor):
                 },
             )
 
-        return (True, {})
-
-    def commit_and_unlock(self, system_storage: SystemStorage) -> Tuple[bool, dict]:
-
-        assert self._parent_node
-        assert self._parent_timestamp
-
-        # FIXME: we shouldn't use writer ID anymore
-        self._counter = system_storage.increase_system_counter(0)
-        if self._counter is None:
-            return (False, {"status": "failure", "reason": "unknown"})
-
         # store the created and the modified version counter
         self._node = Node(self.op.path)
-        self._node.created = Version(self._counter, None)
-        self._node.modified = Version(self._counter, None)
         self._node.children = []
         # we propagate data to another queue, we should use the already
         # base64-encoded data
         # FIXME: keep the information if base64 encoding is actually applied?
         # Important for Redis
         self._node.data_b64 = self.op.data_b64
+
+        return (True, {})
+
+    def commit_and_unlock(self, system_storage: SystemStorage) -> Tuple[bool, dict]:
+
+        assert self._counter
+        assert self._parent_node
+        assert self._parent_timestamp
+
+        self._node.created = Version(self._counter, None)
+        self._node.modified = Version(self._counter, None)
 
         # FIXME: make both operations concurrently
         # unlock parent
@@ -139,18 +142,18 @@ class CreateNodeExecutor(Executor):
 
     def distributor_push(self, client: Client, distributor_queue: DistributorQueue):
 
-        assert self._counter
         assert self._parent_node
-        distributor_queue.push(
-            self._counter,
-            DistributorCreateNode(client.session_id, self._node, self._parent_node),
+        self._counter = distributor_queue.push_and_count(
+            DistributorCreateNode(
+                self.event_id, client.session_id, self._node, self._parent_node
+            ),
             client,
         )
 
 
 class DeregisterSessionExecutor(Executor):
-    def __init__(self, op: DeregisterSession):
-        super().__init__(op)
+    def __init__(self, event_id: str, op: DeregisterSession):
+        super().__init__(event_id, op)
 
     @property
     def op(self) -> DeregisterSession:
@@ -182,10 +185,11 @@ class DeregisterSessionExecutor(Executor):
 
 
 class SetDataExecutor(Executor):
-    def __init__(self, op: SetData):
-        super().__init__(op)
+    def __init__(self, event_id: str, op: SetData):
+        super().__init__(event_id, op)
         self._stats = TimingStatistics.instance()
         self._begin = 0.0
+        self._counter: Optional[SystemCounter] = None
 
     @property
     def op(self) -> SetData:
@@ -217,19 +221,17 @@ class SetDataExecutor(Executor):
                 {"status": "failure", "path": path, "reason": "node_doesnt_exist"},
             )
 
+        self._system_node.data_b64 = self.op.data_b64
+
         return (True, {})
 
     def distributor_push(self, client: Client, distributor_queue: DistributorQueue):
 
-        assert self._counter
         assert self._system_node
 
         begin_push = time.time()
-
-        assert distributor_queue
-        distributor_queue.push(
-            self._counter,
-            DistributorSetData(client.session_id, self._system_node),
+        self._counter = distributor_queue.push_and_count(
+            DistributorSetData(self.event_id, client.session_id, self._system_node),
             client,
         )
         end_push = time.time()
@@ -238,20 +240,12 @@ class SetDataExecutor(Executor):
     def commit_and_unlock(self, system_storage: SystemStorage) -> Tuple[bool, dict]:
 
         assert self._system_node
-
-        begin_atomic = time.time()
-        # FIXME: we shouldn't use writer ID anymore
-        self._counter = system_storage.increase_system_counter(0)
-        if self._counter is None:
-            return (False, {"status": "failure", "reason": "unknown"})
-        end_atomic = time.time()
-        self._stats.add_result("atomic", end_atomic - begin_atomic)
+        assert self._counter
 
         begin_commit = time.time()
         # store only the modified version counter
         # the new data will be written by the distributor
         self._system_node.modified = Version(self._counter, None)
-        self._system_node.data_b64 = self.op.data_b64
         if not system_storage.commit_node(
             self._system_node, self._timestamp, set([NodeDataType.MODIFIED])
         ):
@@ -267,8 +261,8 @@ class SetDataExecutor(Executor):
 
 
 class DeleteNodeExecutor(Executor):
-    def __init__(self, op: DeleteNode):
-        super().__init__(op)
+    def __init__(self, event_id: str, op: DeleteNode):
+        super().__init__(event_id, op)
 
     @property
     def op(self) -> DeleteNode:
@@ -319,14 +313,14 @@ class DeleteNodeExecutor(Executor):
 
     def distributor_push(self, client: Client, distributor_queue: DistributorQueue):
 
-        assert self._counter
         assert self._node
         assert self._parent_node
 
         assert distributor_queue
-        distributor_queue.push(
-            self._counter,
-            DistributorDeleteNode(client.session_id, self._node, self._parent_node),
+        distributor_queue.push_and_count(
+            DistributorDeleteNode(
+                self.event_id, client.session_id, self._node, self._parent_node
+            ),
             client,
         )
 
@@ -336,11 +330,6 @@ class DeleteNodeExecutor(Executor):
         assert self._timestamp
         assert self._parent_node
         assert self._parent_timestamp
-
-        # FIXME: we shouldn't use writer ID anymore
-        self._counter = system_storage.increase_system_counter(0)
-        if self._counter is None:
-            return (False, {"status": "failure", "reason": "unknown"})
 
         # remove child from parent node
         self._parent_node.children.remove(pathlib.Path(self.op.path).name)
@@ -389,4 +378,4 @@ def builder(
         error_msg = {"status": "failure", "reason": "incorrect_request"}
         return (None, error_msg)
 
-    return (executor_type(op), {})
+    return (executor_type(event_id, op), {})

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -153,11 +153,13 @@ class CreateNodeExecutor(Executor):
     def distributor_push(self, client: Client, distributor_queue: DistributorQueue):
 
         assert self._parent_node
+        assert self._parent_timestamp
         self._counter = distributor_queue.push_and_count(
             DistributorCreateNode(
                 self.event_id,
                 client.session_id,
                 self._timestamp,
+                self._parent_timestamp,
                 self._node,
                 self._parent_node,
             ),
@@ -337,6 +339,7 @@ class DeleteNodeExecutor(Executor):
 
         assert self._node
         assert self._parent_node
+        assert self._parent_timestamp
 
         assert distributor_queue
         distributor_queue.push_and_count(
@@ -344,6 +347,7 @@ class DeleteNodeExecutor(Executor):
                 self.event_id,
                 client.session_id,
                 self._timestamp,
+                self._parent_timestamp,
                 self._node,
                 self._parent_node,
             ),

--- a/functions/aws/operations.py
+++ b/functions/aws/operations.py
@@ -155,7 +155,11 @@ class CreateNodeExecutor(Executor):
         assert self._parent_node
         self._counter = distributor_queue.push_and_count(
             DistributorCreateNode(
-                self.event_id, client.session_id, self._node, self._parent_node
+                self.event_id,
+                client.session_id,
+                self._timestamp,
+                self._node,
+                self._parent_node,
             ),
             client,
         )
@@ -241,7 +245,9 @@ class SetDataExecutor(Executor):
 
         begin_push = time.time()
         self._counter = distributor_queue.push_and_count(
-            DistributorSetData(self.event_id, client.session_id, self._system_node),
+            DistributorSetData(
+                self.event_id, client.session_id, self._timestamp, self._system_node
+            ),
             client,
         )
         end_push = time.time()
@@ -335,7 +341,11 @@ class DeleteNodeExecutor(Executor):
         assert distributor_queue
         distributor_queue.push_and_count(
             DistributorDeleteNode(
-                self.event_id, client.session_id, self._node, self._parent_node
+                self.event_id,
+                client.session_id,
+                self._timestamp,
+                self._node,
+                self._parent_node,
             ),
             client,
         )

--- a/functions/aws/writer.py
+++ b/functions/aws/writer.py
@@ -21,13 +21,12 @@ def execute_operation(op_exec: Executor, client: Client) -> Optional[dict]:
         if not status:
             return ret
 
-        # FIXME: revrse the order here
+        assert config.distributor_queue
+        op_exec.distributor_push(client, config.distributor_queue)
+
         status, ret = op_exec.commit_and_unlock(config.system_storage)
         if not status:
             return ret
-
-        assert config.distributor_queue
-        op_exec.distributor_push(client, config.distributor_queue)
 
         return ret
 


### PR DESCRIPTION
Our current algorithm has the problem of potential reordering between two steps: system counter increment and pushing to the distributor queue. In the case of interleaving, two updates can be reordered and applied to the user storage in an incorrect order.

This PR implements a newer, improved version of the algorithm. We apply the following changes:
- [x] DynamoDB streams queue is now deprecated for the distributor queue.
- [x] Committing to system storage happens after successful pushing to the distributor queue.
- [x] Incrementing the system counter & pushing to the distributor queue must happen in a single step.
- [x] Transactional commit of create/delete.
- [x] Committing system storage now adds a pending update.
- [x] Distributor receives the lock timestamp.
- [x] Distributor reads the node from the system storage and verifies it has been committed.
- [x] Distributor verifies the pending update list.
- [x] Distributor attempts second write - if the node is not committed and the lock is still held, then write.
- [x] If the second write failed, distributor checks if it was committed in the end.
- [x] Distributor verifies it's the still original owner to unlock.
- [x] Distributor commits by removing the pending update.
- [x] New node deletion without node deletion