### PR TITLE
watches in aws. Pending watch notification removal in epoch counters

### DIFF
--- a/functions/aws/control/distributor_events.py
+++ b/functions/aws/control/distributor_events.py
@@ -12,10 +12,11 @@ from faaskeeper.node import Node, NodeDataType
 from faaskeeper.version import EpochCounter, SystemCounter, Version
 from faaskeeper.watch import WatchEventType
 from functions.aws.model import SystemStorage
+from functions.aws.model.watches import Watches, WatchType
 from functions.aws.model.system_storage import Node as SystemNode
 from functions.aws.model.user_storage import Storage as UserStorage
 from functions.aws.stats import TimingStatistics
-
+from functions.aws.model.watches import Watches
 
 class DistributorEventType(IntEnum):
     CREATE_NODE = 0
@@ -81,6 +82,20 @@ class DistributorEvent(ABC):
 
     @abstractmethod
     def epoch_counters(self) -> List[str]:
+        pass
+
+    @abstractmethod
+    def generate_watches_event(self, region_watches: Watches) -> List[Watches.Watch_Event]:
+        '''
+        [watchType, path, watchDetails, node_timestamp]
+        '''
+        pass
+
+    @abstractmethod
+    def update_epoch_counters(self, user_storage: UserStorage, epoch_counters: Set[str]):
+        '''
+        store the epoch counters to the EXISTING node (and parent node) in the user storage.
+        '''
         pass
 
     @abstractmethod
@@ -185,7 +200,7 @@ class DistributorCreateNode(DistributorEvent):
     ) -> Optional[dict]:
 
         system_node = system_storage.read_node(self.node)
-
+        print("distributor system node", system_node)
         status = self._node_status(system_node)
 
         if status == TriBool.INCORRECT:
@@ -234,8 +249,8 @@ class DistributorCreateNode(DistributorEvent):
 
         self.node.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
         user_storage.write(self.node)
-        # FIXME: update parent epoch and pxid
-        # self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        # FIXME: update parent pxid
+        self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
         user_storage.update(self.parent, set([NodeDataType.CHILDREN]))
 
         system_storage.pop_pending_update(system_node.node)
@@ -251,10 +266,39 @@ class DistributorCreateNode(DistributorEvent):
         return []
 
     def set_system_counter(self, system_counter: SystemCounter):
-
-        # FIXME: parent counter
         self.node.created = Version(system_counter, None)
         self.node.modified = Version(system_counter, None)
+
+        self.parent.modified = Version(system_counter, None)
+
+    def generate_watches_event(self, region_watches: Watches) -> List[Watches.Watch_Event]:
+        # Query watches from DynaamoDB to decide later, if we should actually invoke call function, then we abstract if statement
+
+        # if they should even be scheduled.
+        all_watches = []
+
+        all_watches += region_watches.query_watches(
+            self.node.path, [WatchType.EXISTS]
+        )
+
+        all_watches += region_watches.query_watches(
+            self.parent.path, [WatchType.GET_CHILDREN]
+        )
+
+        for idx, watch_entity in enumerate(all_watches):
+            # assign node or parent node timestamp to the results
+            if watch_entity[1] == self.node.path:
+                all_watches[idx] = Watches.Watch_Event(WatchEventType.NODE_CREATED.value, watch_entity[0].value, watch_entity[1], self.node.modified.system.sum)
+            elif watch_entity[1] == self.parent.path:
+                all_watches[idx] = Watches.Watch_Event(WatchEventType.NODE_CHILDREN_CHANGED.value, watch_entity[0].value, watch_entity[1], self.parent.modified.system.sum)
+        return all_watches
+
+    def store_epoch_counters(self, user_storage: UserStorage, epoch_counters: Set[str]):
+        self.node.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        user_storage.update(self.node)
+        # FIXME: update pxid.
+        self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        user_storage.update(self.parent, set([NodeDataType.CHILDREN]))
 
     @property
     def node(self) -> Node:
@@ -422,6 +466,20 @@ class DistributorSetData(DistributorEvent):
 
         self.node.modified = Version(system_counter, None)
 
+    def generate_watches_event(self, region_watches: Watches) -> List[Watches.Watch_Event]:
+        all_watches = []
+        all_watches += region_watches.query_watches(
+            self.node.path, [WatchType.GET_DATA, WatchType.EXISTS]
+        )
+
+        for idx, watch_entity in enumerate(all_watches):
+            all_watches[idx] = Watches.Watch_Event(WatchEventType.NODE_DATA_CHANGED.value, watch_entity[0].value, watch_entity[1], self.node.modified.system.sum)
+
+        return all_watches
+
+    def store_epoch_counters(self, user_storage: UserStorage, epoch_counters: Set[str]):
+        self.node.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        user_storage.update(self.node, set([NodeDataType.MODIFIED, NodeDataType.DATA]))
 
 class DistributorDeleteNode(DistributorEvent):
 
@@ -552,7 +610,7 @@ class DistributorDeleteNode(DistributorEvent):
         # FIXME: retain the node to keep counters
         # self.node.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
         user_storage.delete(self.node)
-        # self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
         user_storage.update(self.parent, set([NodeDataType.CHILDREN]))
 
         system_storage.pop_pending_update(system_node.node)
@@ -567,8 +625,34 @@ class DistributorDeleteNode(DistributorEvent):
         return []
 
     def set_system_counter(self, system_counter: SystemCounter):
-        # FIXME: parent counter
-        pass
+        # pass
+        self.node.modified = Version(system_counter, None) # this is for notification use, have nothing to do w/ the node commit
+        self.parent.modified = Version(system_counter, None)
+
+    def generate_watches_event(self, region_watches: Watches) -> List[Watches.Watch_Event]:
+        # Query watches from DynaamoDB to decide later, if we should actually invoke call function, then we abstract if statement
+
+        # if they should even be scheduled.
+        all_watches = []
+        all_watches += region_watches.query_watches(
+            self.node.path, [WatchType.EXISTS, WatchType.GET_DATA, WatchType.GET_CHILDREN]
+        )
+
+        all_watches += region_watches.query_watches(
+            self.parent.path, [WatchType.GET_CHILDREN]
+        )
+
+        for idx, watch_entity in enumerate(all_watches):
+            if watch_entity[1] == self.node.path:
+                all_watches[idx] = Watches.Watch_Event(WatchEventType.NODE_DELETED.value, watch_entity[0].value, watch_entity[1], self.node.modified.system.sum)
+            elif watch_entity[1] == self.parent.path:
+                all_watches[idx] = Watches.Watch_Event(WatchEventType.NODE_CHILDREN_CHANGED.value, watch_entity[0].value, watch_entity[1], self.parent.modified.system.sum)
+
+        return all_watches
+    
+    def store_epoch_counters(self, user_storage: UserStorage, epoch_counters: Set[str]):
+        self.parent.modified.epoch = EpochCounter.from_raw_data(epoch_counters)
+        user_storage.update(self.parent, set([NodeDataType.CHILDREN]))
 
     @property
     def node(self) -> Node:
@@ -597,7 +681,7 @@ def builder(
         raise NotImplementedError()
 
     distr_event = ops[event_type]
-    op = distr_event.deserialize(event)
+    op:DistributorEvent = distr_event.deserialize(event)
     op.set_system_counter(counter)
 
     return op

--- a/functions/aws/distributor.py
+++ b/functions/aws/distributor.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import hashlib
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Dict, List, Set
 
@@ -8,10 +9,9 @@ import boto3
 
 from faaskeeper.stats import StorageStatistics
 from faaskeeper.version import SystemCounter
-from faaskeeper.watch import WatchType
 from functions.aws.config import Config
 from functions.aws.control.channel import Client
-from functions.aws.control.distributor_events import DistributorEventType, builder
+from functions.aws.control.distributor_events import DistributorEvent, DistributorEventType, builder
 from functions.aws.model.watches import Watches
 from functions.aws.stats import TimingStatistics
 
@@ -43,7 +43,7 @@ regions = ["us-east-1"]
 # verbose_output = False
 # FIXME: proper data structure
 region_clients = {}
-region_watches = {}
+region_watches: Dict[str, Watches] = {}
 epoch_counters: Dict[str, Set[str]] = {}
 for r in regions:
     region_clients[r] = boto3.client("lambda", region_name=r)
@@ -56,28 +56,33 @@ def get_object(obj: dict):
     return next(iter(obj.values()))
 
 
-def launch_watcher(region: str, json_in: dict):
+def launch_watcher(operation: DistributorEvent, region: str, json_in: dict):
     """
     (1) Submit watcher
     (2) Wait for completion
     (3) Remove ephemeral counter.
     """
-    # FIXME process result
-    region_clients[region].invoke(
+    is_delivered = region_clients[region].invoke(
         FunctionName=f"{config.deployment_name}-watch",
         InvocationType="RequestResponse",
         Payload=json.dumps(json_in).encode(),
     )
 
-
-# def query_watch_id(region: str, node_path: str):
-#    return region_watches[region].get_watch_counters(node_path)
+    if is_delivered:
+        hashed_path = hashlib.md5(json_in["path"].encode()).hexdigest()
+        timestamp = json_in["timestamp"]
+        watch_type = json_in["type"]
+        
+        # pop the pending watch: update epoch counters for the node and parent in user storage.
+        epoch_counters[r].remove(f"{hashed_path}_{watch_type}_{timestamp}")
+        operation.update_epoch_counters(config.user_storage, epoch_counters[r]) # 结合client那边，或许应该要放到其他地方
+        return True
+    return False
 
 timing_stats = TimingStatistics.instance()
 
 
 def handler(event: dict, context):
-
     events = event["Records"]
     logging.info(f"Begin processing {len(events)} events")
 
@@ -111,7 +116,7 @@ def handler(event: dict, context):
             elif "body" in record:
                 write_event = json.loads(record["body"])
                 event_type = DistributorEventType(int(write_event["type"]["N"]))
-                if "data" in record["messageAttributes"]:
+                if "data" in record["messageAttributes"]: # TODO: is this a case from other operation
                     write_event["data"] = {
                         "B": record["messageAttributes"]["data"]["binaryValue"]
                     }
@@ -150,19 +155,18 @@ def handler(event: dict, context):
                 if config.benchmarking:
                     begin_watch = time.time()
                 # start watch delivery
-                for r in regions:
-                    # if event_type == DistributorEventType.SET_DATA:
-                    #    watches_submitters.append(
-                    #        executor.submit(launch_watcher, r, watches)
-                    #    )
-                    # FIXME: other watchers
-                    # FIXME: reenable submission
-                    # Query watches from DynaamoDB to decide later
-                    # if they should even be scheduled.
-                    region_watches[r].query_watches(
-                        operation.node.path, [WatchType.GET_DATA]
-                    )
+                for r in regions: # deliver watch concurrently
+                    for watch in operation.generate_watches_event(region_watches[r]):
+                        watch_dict = {
+                            "event": watch.watch_event_type,
+                            "type": watch.watch_type,
+                            "path": watch.node_path,
+                            "timestamp": watch.mFxidSys,
+                        }
 
+                        watches_submitters.append(
+                            executor.submit(launch_watcher, operation, r, watch_dict) # watch: {DistributorEvent, watchType, timestamp, path}
+                        )
                 if config.benchmarking:
                     end_watch = time.time()
                     timing_stats.add_result("watch_query", end_watch - begin_watch)

--- a/functions/aws/watch.py
+++ b/functions/aws/watch.py
@@ -19,41 +19,37 @@ def handler(event: dict, context: dict):
 
     try:
         watch_event = WatchEventType(event["event"])
+        watch_type = WatchType(event["type"])
         timestamp = event["timestamp"]
         path = event["path"]
 
         watches_to_retain = []
-        if watch_event == WatchEventType.NODE_DATA_CHANGED:
-            watches = region_watches.get_watches(path, [WatchType.GET_DATA])
-            if len(watches):
-                for client in watches[0][1]:
-                    version = int(client[0])
-                    if version >= timestamp:
-                        if verbose:
-                            print(f"Retaining watch with timestamp {version}")
-                        watches_to_retain.append(client)
-                    else:
-                        client_ip = client[1]
-                        client_port = int(client[2])
-                        if verbose:
-                            print(f"Notify client at {client_ip}:{client_port}")
-                        notify(
-                            client_ip,
-                            client_port,
-                            {
-                                "watch-event": WatchEventType.NODE_DATA_CHANGED.value,
-                                "timestamp": timestamp,
-                                "path": path,
-                            },
-                        )
-                        # FIXME: actual notification
-        else:
-            raise NotImplementedError()
-
-        # FIXME: remove watches from DynamoDB
-
+        watches = region_watches.get_watches(path, [watch_type])
+        if len(watches):
+            for client in watches[0][1]:
+                version = int(client[0])
+                if version >= timestamp:
+                    if verbose:
+                        print(f"Retaining watch with timestamp {version}")
+                    watches_to_retain.append(client)
+                else:
+                    client_ip = client[1]
+                    client_port = int(client[2])
+                    if verbose:
+                        print(f"Notify client at {client_ip}:{client_port}")
+                    notify(
+                        client_ip,
+                        client_port,
+                        {
+                            "watch-event": watch_event.value,
+                            "timestamp": timestamp,
+                            "path": path,
+                        },
+                    )
+        return True
     except Exception:
         print("Failure!")
         import traceback
 
         traceback.print_exc()
+        return False


### PR DESCRIPTION
1. support exists, get children watches for distributor operations. 
2. remove pending watches in the epoch counters and update the node in user storage accordingly.

The full work is comprised of changed made in this repo, and another PR (I will provide a link when it is open) in the `faaskeeper-client` repo. But note that, merging this PR alone will not break the system.

Here are the things to be merged into `faaskeeper-client` repo:
1. partial removal of some watches in a path in get_watches() in `queue.py`
2. generate messages for all watches of the paths overlapped in the node epoch counters in the SorterThread. 